### PR TITLE
INT-544 handle bad response issue when adding query to a job

### DIFF
--- a/lib/salesforce_bulk/empty_response_exception.rb
+++ b/lib/salesforce_bulk/empty_response_exception.rb
@@ -1,4 +1,0 @@
-module SalesforceBulk
-  class EmptyResponseException < StandardError
-  end
-end

--- a/lib/salesforce_bulk/empty_response_exception.rb
+++ b/lib/salesforce_bulk/empty_response_exception.rb
@@ -1,0 +1,4 @@
+module SalesforceBulk
+  class EmptyResponseException < StandardError
+  end
+end

--- a/lib/salesforce_bulk/job.rb
+++ b/lib/salesforce_bulk/job.rb
@@ -63,9 +63,10 @@ module SalesforceBulk
       headers = Hash["Content-Type" => "text/csv; charset=UTF-8"]
       response = @@connection.post_xml(nil, path, @@records, headers)
       response_parsed = XmlSimple.xml_in(response)
-      ids = response_parsed['id'] unless response_parsed.nil?
-      if ids.nil? or ids[0].blank?
-        raise EmptyResponseException "Got empty response adding query to the SF job id #{@@job_id}"
+      ids = response_parsed['id']
+      if ids.nil?
+	exception_message = response_parsed['exceptionMessage'][0]
+        raise SalesforceApiException exception_message
       end
       @@batch_id = ids[0]
     end

--- a/lib/salesforce_bulk/job.rb
+++ b/lib/salesforce_bulk/job.rb
@@ -63,8 +63,11 @@ module SalesforceBulk
       headers = Hash["Content-Type" => "text/csv; charset=UTF-8"]
       response = @@connection.post_xml(nil, path, @@records, headers)
       response_parsed = XmlSimple.xml_in(response)
-
-      @@batch_id = response_parsed['id'][0]
+      ids = response_parsed['id'] unless response_parsed.nil?
+      if ids.nil? or ids[0].blank?
+        raise EmptyResponseException "Got empty response adding query to the SF job id #{@@job_id}"
+      end
+      @@batch_id = ids[0]
     end
 
     def add_batch()

--- a/lib/salesforce_bulk/salesforce_api_exception.rb
+++ b/lib/salesforce_bulk/salesforce_api_exception.rb
@@ -1,0 +1,4 @@
+module SalesforceBulk
+  class SalesforceApiException < StandardError
+  end
+end


### PR DESCRIPTION
When a SF query is added to the job, at times SF returns an XML response without batch ID or job ID. It seems to happen when ApiBatchLimit has been hit. And the salesforce_bulk gem we use does not handle this scenario gracefully. 
It leads to annoying rollbar noise which lasts for quite a while until rate limit clears and things are back to normal. 
https://rollbar.com/justworks/clockwork_web/items/7252
https://rollbar.com/justworks/clockwork_web/items/7251

This PR has changes to handle such scenarios, and raise a custom exception. It will help calling client (i.e. clockwork salesforce.rake task) to handle it gracefully. (PR for that to follow once we merge this and upgrade clockwork to this version of the gem)

Below ticket has more details on the debugging done.
Reference:
https://justworks.atlassian.net/browse/GROWTH-19

SF API Batch documentation:
https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_batches_create.htm